### PR TITLE
code-block iam role names to avoid markdown confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ DPS + abbrev pipeline name + Role
 
 examples:
 
+```
 arn:aws:iam::*:role/DPSIamProfilesRole  
 arn:aws:iam::*:role/DPSPlatformEksBaseRole  
 arn:aws:iam::*:role/DPSPlatformEksCoreServicesRole  
+```
 
 ## DataDog
 


### PR DESCRIPTION
**Summary**

Without this, the `*` are not displayed, but render as italics.
